### PR TITLE
revive http functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,15 @@ smallvec = { version = "1", default-features = false, optional = true }
 tokio = { version = "1", features = ["io-util", "rt"], optional = true }
 tokio-util = { version = "0.7", default-features = false, optional = true }
 
+# x- features are experimental and have no expectation of API stability whatsoever. Use at your own risk.
 [features]
-http = ["reqwest"]
+x-http = ["reqwest"]
 tokio-io = ["tokio", "smallvec"]
 stats = []
-default = ["tokio-io", "http"]
+default = ["tokio-io", "x-http"]
 
 [package.metadata.docs.rs]
-features = ["http", "tokio-io", "stats"]
+features = ["x-http", "tokio-io", "stats"]
 
 [dev-dependencies]
 axum = { version = "0.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tokio-util = { version = "0.7", default-features = false, optional = true }
 x-http = ["reqwest"]
 tokio-io = ["tokio", "smallvec"]
 stats = []
-default = ["tokio-io", "x-http"]
+default = ["tokio-io"]
 
 [package.metadata.docs.rs]
 features = ["x-http", "tokio-io", "stats"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio-util = { version = "0.7", default-features = false, optional = true }
 http = ["reqwest"]
 tokio-io = ["tokio", "smallvec"]
 stats = []
-default = ["tokio-io"]
+default = ["tokio-io", "http"]
 
 [package.metadata.docs.rs]
 features = ["http", "tokio-io", "stats"]

--- a/proptest-regressions/lib.txt
+++ b/proptest-regressions/lib.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 731a6483e8e791e2cf1824ff3591d4e1b719ee544fbccfa8bfce3a5744f4aba1 # shrinks to data = [0], ops = [ReadSequential(0, 1), ReadAt(0, 0)]
+cc 56cce28c48dc37dd34acfafd1604a8a8bdc8da9d2656836729f9f3a8bf54444f # shrinks to data = [], ops = [ReadAt(0, 0), ReadAt(0, 0)]

--- a/src/http.rs
+++ b/src/http.rs
@@ -30,22 +30,20 @@ impl fmt::Debug for HttpAdapter {
 
 impl HttpAdapter {
     /// Creates a new [`HttpAdapter`] from a URL
-    pub async fn new(url: Url) -> io::Result<Self> {
-        Self::with_opts(url, Default::default()).await
+    pub fn new(url: Url) -> Self {
+        Self::with_opts(url, Default::default())
     }
 
     /// Creates a new [`HttpAdapter`] from a URL and options
-    pub async fn with_opts(url: Url, opts: http_adapter::Opts) -> io::Result<Self> {
+    pub fn with_opts(url: Url, opts: http_adapter::Opts) -> Self {
         let client = reqwest::Client::new();
 
-        let mut res = Self {
+        Self {
             client,
             opts,
             url,
             size: None,
-        };
-        res.len().await?;
-        Ok(res)
+        }
     }
 
     async fn head_request(&self) -> Result<reqwest::Response, reqwest::Error> {
@@ -151,6 +149,7 @@ pub mod http_adapter {
     #[derive(Debug, Clone, Default)]
     pub struct Opts {
         pub(crate) headers: Option<HeaderMap<HeaderValue>>,
+        pub(crate) client: Option<reqwest::Client>,
     }
 
     impl AsyncSliceReader for HttpAdapter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -802,7 +802,7 @@ mod tests {
         println!("serving from {}", url);
         let url = reqwest::Url::parse(&url).unwrap();
         let server = tokio::spawn(server);
-        let mut reader = HttpAdapter::new(url).await.unwrap();
+        let mut reader = HttpAdapter::new(url);
         let len = reader.len().await.unwrap();
         assert_eq!(len, 11);
         println!("len: {:?}", reader);
@@ -855,7 +855,7 @@ mod tests {
                 let server = tokio::spawn(server);
                 // create a resource from the server
                 let url = reqwest::Url::parse(&format!("http://{}", addr)).unwrap();
-                let file = HttpAdapter::new(url).await.unwrap();
+                let file = HttpAdapter::new(url);
                 // run the test
                 read_op_test(ops, file, &data).await.unwrap();
                 // stop the server

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,9 +226,9 @@ pub use tokio_io::*;
 #[cfg(feature = "stats")]
 pub mod stats;
 
-#[cfg(feature = "http")]
+#[cfg(feature = "x-http")]
 mod http;
-#[cfg(feature = "http")]
+#[cfg(feature = "x-http")]
 pub use http::*;
 
 /// implementations for [AsyncSliceReader] and [AsyncSliceWriter] for [bytes::Bytes] and [bytes::BytesMut]
@@ -344,7 +344,7 @@ where
     }
 }
 
-#[cfg(any(feature = "tokio-io", feature = "http"))]
+#[cfg(any(feature = "tokio-io", feature = "x-http"))]
 fn make_io_error<E>(e: E) -> io::Error
 where
     E: Into<Box<dyn std::error::Error + Send + Sync>>,
@@ -366,7 +366,7 @@ mod tests {
     use std::io::Write;
 
     /// A test server that serves data on a random port, supporting head, get, and range requests
-    #[cfg(feature = "http")]
+    #[cfg(feature = "x-http")]
     mod test_server {
         use super::*;
         use axum::{routing::get, Extension, Router};
@@ -685,7 +685,7 @@ mod tests {
         io::Result::Ok(())
     }
 
-    // #[cfg(feature = "http")]
+    // #[cfg(feature = "x-http")]
     // #[tokio::test]
     // async fn test_http_range() -> io::Result<()> {
     //     let url = reqwest::Url::parse("https://ipfs.io/ipfs/bafybeiaj2dgwpi6bsisyf4wq7yvj4lqvpbmlmztm35hqyqqjihybnden24/image").unwrap();
@@ -697,7 +697,7 @@ mod tests {
     //     Ok(())
     // }
 
-    #[cfg(feature = "http")]
+    #[cfg(feature = "x-http")]
     #[tokio::test]
     #[cfg_attr(target_os = "windows", ignore)]
     async fn http_smoke() {
@@ -748,7 +748,7 @@ mod tests {
             async_test(read_op_test(ops, File::from_std(file), &data)).unwrap();
         }
 
-        #[cfg(feature = "http")]
+        #[cfg(feature = "x-http")]
         #[cfg_attr(target_os = "windows", ignore)]
         #[test]
         fn http_read(data in proptest::collection::vec(any::<u8>(), 0..10), ops in random_read_ops(10, 10, 2)) {

--- a/src/tokio_io.rs
+++ b/src/tokio_io.rs
@@ -59,7 +59,7 @@ impl File {
     }
 }
 
-/// Futures for the [File]
+/// Support for the [File]
 pub mod file {
     use bytes::Bytes;
 
@@ -270,13 +270,6 @@ impl<W: AsyncWrite + Unpin + 'static> AsyncSliceWriter for ConcatenateSliceWrite
     }
 }
 
-/// Futures for [ConcatenateSliceWriter].
-pub mod concatenate_slice_writer {
-    use super::*;
-
-    pub use tokio_helper::{Flush as Sync, Write as WriteAt, WriteBytes as WriteBytesAt};
-}
-
 /// Utility to convert a [tokio::io::AsyncWrite] into an [AsyncStreamWriter].
 #[derive(Debug, Clone)]
 pub struct TokioStreamWriter<T>(pub T);
@@ -305,13 +298,6 @@ impl<T: tokio::io::AsyncRead + Unpin> AsyncStreamReader for TokioStreamReader<T>
         (&mut self.0).take(len as u64).read_to_end(&mut buf).await?;
         Ok(buf.into())
     }
-}
-
-/// Futures for [TokioStreamWriter].
-pub mod tokio_stream_writer {
-    use super::*;
-
-    pub use tokio_helper::{Flush as Sync, Write, WriteBytes};
 }
 
 /// Futures copied from tokio, because they are private in tokio


### PR DESCRIPTION
iroh-io was developed with http as a backend in mind, but we never used it so far. This revives the http feature.