### PR TITLE
feat: add read_exact variants to all readers

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -2,16 +2,16 @@
 //!
 //! Uses the [reqwest](https://docs.rs/reqwest) crate. Somewhat inspired by
 //! <https://github.com/fasterthanlime/ubio/blob/main/src/http/mod.rs>
-use self::http_adapter::Opts;
+use std::{pin::Pin, str::FromStr, sync::Arc};
 
-use super::*;
 use futures_lite::{Stream, StreamExt};
 use reqwest::{
     header::{HeaderMap, HeaderValue},
     Method, StatusCode, Url,
 };
-use std::str::FromStr;
-use std::{pin::Pin, sync::Arc};
+
+use self::http_adapter::Opts;
+use super::*;
 
 /// A struct that implements [AsyncSliceReader] using HTTP range requests
 #[derive(Debug)]
@@ -147,7 +147,7 @@ pub mod http_adapter {
         }
 
         async fn size(&mut self) -> io::Result<u64> {
-            let io_err = |text: &str| io::Error::new(io::ErrorKind::Other, text);
+            let io_err = |text: &str| io::Error::other(text);
             let head_response = self
                 .head_request()
                 .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,21 @@ pub trait AsyncSliceReader {
     #[must_use = "io futures must be polled to completion"]
     fn read_at(&mut self, offset: u64, len: usize) -> impl Future<Output = io::Result<Bytes>>;
 
+    /// Variant of read_at that returns an error if less than `len` bytes are read.
+    fn read_exact_at(
+        &mut self,
+        offset: u64,
+        len: usize,
+    ) -> impl Future<Output = io::Result<Bytes>> {
+        async move {
+            let res = self.read_at(offset, len).await?;
+            if res.len() < len {
+                return Err(io::ErrorKind::UnexpectedEof.into());
+            }
+            Ok(res)
+        }
+    }
+
     /// Get the length of the resource
     #[must_use = "io futures must be polled to completion"]
     fn size(&mut self) -> impl Future<Output = io::Result<u64>>;
@@ -178,6 +193,29 @@ pub trait AsyncStreamReader {
     ///
     /// If there are less than L bytes available, an io::ErrorKind::UnexpectedEof error is returned.
     fn read<const L: usize>(&mut self) -> impl Future<Output = io::Result<[u8; L]>>;
+
+
+    /// Variant of read_bytes that returns an error if less than `len` bytes are read.
+    fn read_bytes_exact(&mut self, len: usize) -> impl Future<Output = io::Result<Bytes>> {
+        async move {
+            let res = self.read_bytes(len).await?;
+            if res.len() < len {
+                return Err(io::ErrorKind::UnexpectedEof.into());
+            }
+            Ok(res)
+        }
+    }
+
+    /// Variant of read that returns an error if less than `L` bytes are read.
+    fn read_exact<const L: usize>(&mut self) -> impl Future<Output = io::Result<[u8; L]>> {
+        async move {
+            let res = self.read::<L>().await?;
+            if res.len() < L {
+                return Err(io::ErrorKind::UnexpectedEof.into());
+            }
+            Ok(res)
+        }
+    }
 }
 
 impl<T: AsyncStreamReader> AsyncStreamReader for &mut T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,12 @@
 //! an allocation.
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
+use std::{
+    future::Future,
+    io::{self, Cursor},
+};
+
 use bytes::{Buf, Bytes, BytesMut};
-use std::future::Future;
-use std::io::{self, Cursor};
 
 /// A trait to abstract async reading from different resource.
 ///
@@ -82,7 +85,7 @@ pub trait AsyncSliceReader {
     fn size(&mut self) -> impl Future<Output = io::Result<u64>>;
 }
 
-impl<'b, T: AsyncSliceReader> AsyncSliceReader for &'b mut T {
+impl<T: AsyncSliceReader> AsyncSliceReader for &mut T {
     async fn read_at(&mut self, offset: u64, len: usize) -> io::Result<Bytes> {
         (**self).read_at(offset, len).await
     }
@@ -146,7 +149,7 @@ pub trait AsyncSliceWriter: Sized {
     fn sync(&mut self) -> impl Future<Output = io::Result<()>>;
 }
 
-impl<'b, T: AsyncSliceWriter> AsyncSliceWriter for &'b mut T {
+impl<T: AsyncSliceWriter> AsyncSliceWriter for &mut T {
     async fn write_at(&mut self, offset: u64, data: &[u8]) -> io::Result<()> {
         (**self).write_at(offset, data).await
     }
@@ -193,7 +196,6 @@ pub trait AsyncStreamReader {
     ///
     /// If there are less than L bytes available, an io::ErrorKind::UnexpectedEof error is returned.
     fn read<const L: usize>(&mut self) -> impl Future<Output = io::Result<[u8; L]>>;
-
 
     /// Variant of read_bytes that returns an error if less than `len` bytes are read.
     fn read_bytes_exact(&mut self, len: usize) -> impl Future<Output = io::Result<Bytes>> {
@@ -439,28 +441,30 @@ fn make_io_error<E>(e: E) -> io::Error
 where
     E: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
-    io::Error::new(io::ErrorKind::Other, e)
+    io::Error::other(e)
 }
 
 #[cfg(test)]
 mod tests {
 
-    use crate::mem::limited_range;
-
-    use super::*;
-    use proptest::prelude::*;
     use std::fmt::Debug;
-
     #[cfg(feature = "tokio-io")]
     use std::io::Write;
+
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::mem::limited_range;
 
     /// A test server that serves data on a random port, supporting head, get, and range requests
     #[cfg(feature = "x-http")]
     mod test_server {
-        use super::*;
+        use std::{net::SocketAddr, ops::Range, sync::Arc};
+
         use axum::{routing::get, Extension, Router};
         use hyper::{Body, Request, Response, StatusCode};
-        use std::{net::SocketAddr, ops::Range, sync::Arc};
+
+        use super::*;
 
         pub fn serve(data: Vec<u8>) -> (SocketAddr, impl Future<Output = hyper::Result<()>>) {
             // Create an Axum router

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,6 +1,8 @@
-use super::{AsyncSliceReader, AsyncSliceWriter};
-use bytes::{Bytes, BytesMut};
 use std::io;
+
+use bytes::{Bytes, BytesMut};
+
+use super::{AsyncSliceReader, AsyncSliceWriter};
 
 impl AsyncSliceReader for bytes::Bytes {
     async fn read_at(&mut self, offset: u64, len: usize) -> io::Result<Bytes> {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -414,7 +414,7 @@ impl<'a, F: Future> AggregateStats<'a, F> {
     }
 }
 
-impl<'a, F: Future> Future for AggregateStats<'a, F> {
+impl<F: Future> Future for AggregateStats<'_, F> {
     type Output = F::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -466,7 +466,7 @@ impl<T: AsRef<[u8]>> ReadResult for std::io::Result<T> {
     }
 }
 
-impl<'a, F: Future> Future for AggregateSizeAndStats<'a, F>
+impl<F: Future> Future for AggregateSizeAndStats<'_, F>
 where
     F::Output: ReadResult,
 {

--- a/src/tokio_io.rs
+++ b/src/tokio_io.rs
@@ -45,6 +45,7 @@ impl File {
         Self::create(move || std::fs::File::open(path)).await
     }
 
+    /// Test helper to read the contents of the file
     #[cfg(test)]
     pub fn read_contents(&self) -> Vec<u8> {
         let mut std_file = &self.0.as_ref().unwrap().0;

--- a/src/tokio_io.rs
+++ b/src/tokio_io.rs
@@ -1,6 +1,4 @@
 //! Blocking io for [std::fs::File], using the tokio blocking task pool.
-use bytes::Bytes;
-use pin_project::pin_project;
 use std::{
     future::Future,
     io::{self, Read, Seek, SeekFrom},
@@ -8,14 +6,16 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+
+use bytes::Bytes;
+use pin_project::pin_project;
 use tokio::{
     io::{AsyncReadExt, AsyncWrite},
     task::{spawn_blocking, JoinHandle},
 };
 
-use crate::AsyncStreamReader;
-
 use super::{make_io_error, AsyncSliceReader, AsyncSliceWriter, AsyncStreamWriter};
+use crate::AsyncStreamReader;
 
 const MAX_PREALLOC: usize = 1024 * 16;
 
@@ -138,11 +138,10 @@ impl<'a, T: 'a, R> Future for Asyncify<'a, R, T> {
                         **h = Some(state);
                         r
                     }
-                    Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
+                    Err(e) => Err(io::Error::other(e)),
                 }
             }),
-            AsyncifyProj::BusyErr => Poll::Ready(io::Result::Err(io::Error::new(
-                io::ErrorKind::Other,
+            AsyncifyProj::BusyErr => Poll::Ready(io::Result::Err(io::Error::other(
                 "previous io op not polled to completion",
             ))),
         }


### PR DESCRIPTION
In many cases when working with bao we know exactly how much we want to read and want to fail early if we get less.

Note that this was not a big problem before because read_at and read only ever do short reads if there is an actual EOF, not if there is no data available.